### PR TITLE
Changing reference from Netbox custom MultipleChoiceField subclass and adding Polish currency.

### DIFF
--- a/src/netbox_contract/forms.py
+++ b/src/netbox_contract/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib.contenttypes.models import ContentType
 import django_filters
 from netbox.forms import NetBoxModelForm, NetBoxModelFilterSetForm, NetBoxModelBulkEditForm, NetBoxModelImportForm
-from utilities.forms.fields import CommentField, CSVChoiceField, DynamicModelChoiceField, DynamicModelMultipleChoiceField, MultipleChoiceField, CSVModelChoiceField, SlugField, CSVContentTypeField
+from utilities.forms.fields import CommentField, CSVChoiceField, DynamicModelChoiceField, DynamicModelMultipleChoiceField, CSVModelChoiceField, SlugField, CSVContentTypeField
 from utilities.forms.widgets import DatePicker
 from extras.filters import TagFilter
 from circuits.models import Circuit
@@ -66,9 +66,9 @@ class ContractFilterSetForm(NetBoxModelFilterSetForm):
     internal_partie= forms.CharField(
         required=False
     )
-    status = MultipleChoiceField(
+    status = django_filters.MultipleChoiceField(
         choices=StatusChoices,
-        required= False
+        required=False
     )
     parent=DynamicModelChoiceField(
         queryset=Contract.objects.all(),

--- a/src/netbox_contract/forms.py
+++ b/src/netbox_contract/forms.py
@@ -66,7 +66,7 @@ class ContractFilterSetForm(NetBoxModelFilterSetForm):
     internal_partie= forms.CharField(
         required=False
     )
-    status = django_filters.MultipleChoiceField(
+    status = django_filters.MultipleChoiceFilter(
         choices=StatusChoices,
         required=False
     )

--- a/src/netbox_contract/models.py
+++ b/src/netbox_contract/models.py
@@ -35,6 +35,7 @@ class CurrencyChoices(ChoiceSet):
         (CURRENCY_USD, 'USD'),
         ('eur', 'EUR'),
         ('chf', 'CHF'),
+        ('pln', 'PLN'),
     ]
 
 class ServiceProvider(NetBoxModel):


### PR DESCRIPTION
Hello,

I changing reference from Netbox custom MultipleChoiceField subclass to django_filter MultipleChoiceFilter. Netbox custom MultipleChoiceField subclass from utilities.forms.fields was removed in version 3.6 Netbox [https://github.com/netbox-community/netbox/pull/13614](https://github.com/netbox-community/netbox/pull/13614). In addition, I added the Polish currency Polish Zloty (PLN) to the currency array.

Regards