### PR TITLE
Quick search only filters active contracts

### DIFF
--- a/src/netbox_contract/filtersets.py
+++ b/src/netbox_contract/filtersets.py
@@ -14,6 +14,7 @@ class ContractFilterSet(NetBoxModelFilterSet):
             Q(name__icontains=value)
             | Q(external_reference__icontains=value)
             | Q(comments__icontains=value)
+            | Q(status__iexact='Active')
         )
 
 


### PR DESCRIPTION
On branch 105-quick-search-only-active-contracts
Changes to be committed:
	modified:   src/netbox_contract/filtersets.py