### PR TITLE
Add first currency as default

### DIFF
--- a/src/netbox_contract/models.py
+++ b/src/netbox_contract/models.py
@@ -52,6 +52,7 @@ class CurrencyChoices(ChoiceSet):
         ('chf', 'CHF'),
     ]
 
+CURRENCY_DEFAULT = CurrencyChoices.CHOICES[0][0]
 
 class AccountingDimension(NetBoxModel):
     name = models.CharField(max_length=20)
@@ -151,7 +152,7 @@ class Contract(NetBoxModel):
         help_text='In month', default=12, blank=True, null=True
     )
     currency = models.CharField(
-        max_length=3, choices=CurrencyChoices, default=CurrencyChoices.CURRENCY_USD
+        max_length=3, choices=CurrencyChoices, default=CURRENCY_DEFAULT
     )
     accounting_dimensions = models.JSONField(null=True, blank=True)
     yrc = models.DecimalField(
@@ -207,7 +208,7 @@ class Invoice(NetBoxModel):
     period_start = models.DateField(blank=True, null=True)
     period_end = models.DateField(blank=True, null=True)
     currency = models.CharField(
-        max_length=3, choices=CurrencyChoices, default=CurrencyChoices.CURRENCY_USD
+        max_length=3, choices=CurrencyChoices, default=CURRENCY_DEFAULT
     )
     accounting_dimensions = models.JSONField(null=True)
     amount = models.DecimalField(max_digits=10, decimal_places=2)
@@ -236,7 +237,7 @@ class InvoiceLine(NetBoxModel):
         to='Invoice', on_delete=models.CASCADE, related_name='invoicelines'
     )
     currency = models.CharField(
-        max_length=3, choices=CurrencyChoices, default=CurrencyChoices.CURRENCY_USD
+        max_length=3, choices=CurrencyChoices, default=CURRENCY_DEFAULT
     )
     amount = models.DecimalField(max_digits=10, decimal_places=2)
     accounting_dimensions = models.ManyToManyField(AccountingDimension, blank=True)


### PR DESCRIPTION
Hello,

As we are not using USD as default currency we want to be able to select the first currency from the `ChoiceSet` as default as we'd like to avoid changing it every time we create a contract.

With this modification we can used the `FIELD_CHOICES` and the first element of the list will be proposed as default.

For configuration without `FIELD_CHOICES` no changed as USD is still the first choice.

```

    CHOICES = [
        (CURRENCY_USD, 'USD'),
        ('eur', 'EUR'),
        ('chf', 'CHF'),
    ]
```