### PR TITLE
fix(ui) invisible link as no data was attached to the href

### DIFF
--- a/src/netbox_contract/templates/netbox_contract/contractassignment.html
+++ b/src/netbox_contract/templates/netbox_contract/contractassignment.html
@@ -12,7 +12,7 @@
             </tr>
             <tr>
               <th scope="row">{% trans "Object" %}</th>
-              <td><a href="{{ object.content_object.get_absolute_url }}">{{ object.content_object.name }}</a></td>
+              <td><a href="{{ object.content_object.get_absolute_url }}">{{ object.content_object }}</a></td>
             </tr>
             <tr>
               <th scope="row">{% trans "Contract" %}</th>


### PR DESCRIPTION
On view `/plugins/contracts/assignments/<id>` object was emtpy. 

The template was matching for name but name is not existing.

previously:

![image](https://github.com/user-attachments/assets/843e2cc9-c56d-4d68-877d-ab8bccb781a7)

![image](https://github.com/user-attachments/assets/6736fc25-2f2f-4d07-91c0-3551e2e4230d)

