### PR TITLE
fix(ui): currency not display as label

### DIFF
--- a/src/netbox_contract/templates/netbox_contract/contract.html
+++ b/src/netbox_contract/templates/netbox_contract/contract.html
@@ -76,7 +76,7 @@
             {% endif %}
             <tr>
               <th scope="row">{% trans "Currency" %}</th>
-              <td>{{ object.currency }}</td>
+              <td>{{ object.get_currency_display  }}</td>
             </tr>
             <tr>
               <th scope="row">{% trans "Monthly recuring costs" %}</th>
@@ -135,7 +135,7 @@
           </tr>
           <tr>
             <th scope="row">{% trans "Currency" %}</th>
-            <td>{{ invoice_template.currency }}</td>
+            <td>{{ invoice_template.get_currency_display  }}</td>
           </tr>
           <tr>
             <th scope="row">{% trans "Total amount" %}</th>

--- a/src/netbox_contract/templates/netbox_contract/invoice.html
+++ b/src/netbox_contract/templates/netbox_contract/invoice.html
@@ -40,7 +40,7 @@
             {% endif %}
             <tr>
               <th scope="row">{% trans "Currency" %}</th>
-              <td>{{ object.currency }}</td>
+              <td>{{ object.get_currency_display  }}</td>
             </tr>
             <tr>
               <th scope="row">{% trans "Amount" %}</th>

--- a/src/netbox_contract/templates/netbox_contract/invoiceline.html
+++ b/src/netbox_contract/templates/netbox_contract/invoiceline.html
@@ -26,7 +26,7 @@
             </tr>
             <tr>
               <th scope="row">{% trans "Currency" %}</th>
-              <td>{{ object.currency }}</td>
+              <td>{{ object.get_currency_display  }}</td>
             </tr>
             <tr>
               <th scope="row">{% trans "Accounting dimensions" %}</th>


### PR DESCRIPTION
Hi,

Unify the currency view to always show the label.

Example with tis input:
```
    'netbox_contract.Contract.currency': (
        ('usd', 'USD'),
        ('eur', 'EUR'),
        ('chf', 'CHF'),
        ('pln', 'PLN'),
    ),
```

The currency was EUR (label) in the table and eur (value) on the views (/plugins/contracts/contracts/<id>)

This is now consistent with the standard label.





