### PR TITLE
fix(upgrade) Netbox4.2 non-editable field

### DIFF
--- a/src/netbox_contract/models.py
+++ b/src/netbox_contract/models.py
@@ -151,6 +151,7 @@ class Contract(NetBoxModel):
     external_partie_object = GenericForeignKey(
         ct_field='external_partie_object_type', fk_field='external_partie_object_id'
     )
+    external_partie_object.editable = True
     external_reference = models.CharField(max_length=100, blank=True, null=True, verbose_name=_('external reference'))
     internal_partie = models.CharField(max_length=50, choices=InternalEntityChoices, verbose_name=_('internal partie'))
     tenant = models.ForeignKey(


### PR DESCRIPTION
Fix #219 #208 

With Netbox 4.2, the Django have been updated to Django 5.1

This change the default editable value for GenericForeignKey

This is explain here
https://forum.djangoproject.com/t/non-editable-error-for-a-genericforeignkey-in-an-modelform-when-updating-to-version-5-1/35033/4

This is a quick fix by reconfiguring the field to be editable.

Tested with succes with Netbox 4.2.1