### PR TITLE
Replace word partie with party

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Version 2.4.1
+
+* [261](https://github.com/mlebreuil/netbox-contract/issues/261) Fix spelling of word "party".
 
 ## Version 2
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ PLUGINS_CONFIG = {
 
 ### Customize the plugin fields choices
 
-Internal partie reference the legal entity of your organization that is a partie to the contract.  
+Internal party reference the legal entity of your organization that is a party to the contract.  
 The first currency will also be the default currency for contracts.  
 
 ```python
 # configuration.py
 FIELD_CHOICES = {
-    'netbox_contract.Contract.internal_partie': (
+    'netbox_contract.Contract.internal_party': (
         ('default', 'Default entity', 'green'),
         ('entity1', 'Entity 1', 'green'),
         ('entity2', 'Entity 2', 'yellow'),

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -4,7 +4,7 @@
 
 ![Contract](img/contract.png "contract")
 
-- External partie type: either an Circuit provider or Contract Service provider.
+- External party type: either an Circuit provider or Contract Service provider.
 - Accounting dimensions: Will be copied to each invoice. Although this this field is still available the use invoice templates with accounting dimensions should be prefered.
 - Monthly / Yearly recuring costs: Only one of these two options can be used for each contract. The value will be used, along with the invoice frequency, to calculate each invoice amount.
 - Invoice frequency : The number of month that each invoice covers.

--- a/netbox_contract/__init__.py
+++ b/netbox_contract/__init__.py
@@ -5,7 +5,7 @@ class ContractsConfig(PluginConfig):
     name = 'netbox_contract'
     verbose_name = 'Netbox contract'
     description = 'Contract management plugin for Netbox'
-    version = '2.4.0'
+    version = '2.4.1'
     author = 'Marc Lebreuil'
     author_email = 'marc@famillelebreuil.net'
     base_url = 'contracts'

--- a/netbox_contract/api/serializers.py
+++ b/netbox_contract/api/serializers.py
@@ -24,8 +24,8 @@ class NestedContractSerializer(WritableNestedSerializer):
     )
     yrc = serializers.DecimalField(max_digits=10, decimal_places=2, read_only=True)
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
-    external_partie_object_type = ContentTypeField(queryset=ContentType.objects.all())
-    external_partie_object = serializers.SerializerMethodField(read_only=True)
+    external_party_object_type = ContentTypeField(queryset=ContentType.objects.all())
+    external_party_object = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Contract
@@ -34,11 +34,11 @@ class NestedContractSerializer(WritableNestedSerializer):
             'url',
             'display',
             'name',
-            'external_partie_object_type',
-            'external_partie_object_id',
-            'external_partie_object',
+            'external_party_object_type',
+            'external_party_object_id',
+            'external_party_object',
             'external_reference',
-            'internal_partie',
+            'internal_party',
             'tenant',
             'status',
             'start_date',
@@ -54,13 +54,13 @@ class NestedContractSerializer(WritableNestedSerializer):
         )
 
     @swagger_serializer_method(serializer_or_field=serializers.JSONField)
-    def get_external_partie_object(self, instance):
+    def get_external_party_object(self, instance):
         serializer = get_serializer_for_model(
-            instance.external_partie_object_type.model_class()
+            instance.external_party_object_type.model_class()
         )
         context = {'request': self.context['request']}
         return serializer(
-            instance.external_partie_object, nested=True, context=context
+            instance.external_party_object, nested=True, context=context
         ).data
 
 
@@ -93,8 +93,8 @@ class ContractSerializer(NetBoxModelSerializer):
     yrc = serializers.DecimalField(max_digits=10, decimal_places=2, read_only=True)
     parent = NestedContractSerializer(many=False, required=False)
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
-    external_partie_object_type = ContentTypeField(queryset=ContentType.objects.all())
-    external_partie_object = serializers.SerializerMethodField(read_only=True)
+    external_party_object_type = ContentTypeField(queryset=ContentType.objects.all())
+    external_party_object = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Contract
@@ -103,11 +103,11 @@ class ContractSerializer(NetBoxModelSerializer):
             'url',
             'display',
             'name',
-            'external_partie_object_type',
-            'external_partie_object_id',
-            'external_partie_object',
+            'external_party_object_type',
+            'external_party_object_id',
+            'external_party_object',
             'external_reference',
-            'internal_partie',
+            'internal_party',
             'tenant',
             'status',
             'start_date',
@@ -131,11 +131,11 @@ class ContractSerializer(NetBoxModelSerializer):
             'url',
             'display',
             'name',
-            'external_partie_object_type',
-            'external_partie_object_id',
-            'external_partie_object',
+            'external_party_object_type',
+            'external_party_object_id',
+            'external_party_object',
             'external_reference',
-            'internal_partie',
+            'internal_party',
             'tenant',
             'status',
             'start_date',
@@ -152,13 +152,13 @@ class ContractSerializer(NetBoxModelSerializer):
         )
 
     @swagger_serializer_method(serializer_or_field=serializers.JSONField)
-    def get_external_partie_object(self, instance):
+    def get_external_party_object(self, instance):
         serializer = get_serializer_for_model(
-            instance.external_partie_object_type.model_class()
+            instance.external_party_object_type.model_class()
         )
         context = {'request': self.context['request']}
         return serializer(
-            instance.external_partie_object, nested=True, context=context
+            instance.external_party_object, nested=True, context=context
         ).data
 
 

--- a/netbox_contract/filtersets.py
+++ b/netbox_contract/filtersets.py
@@ -20,7 +20,7 @@ from .models import (
 
 class ContractFilterSet(ContactModelFilterSet, NetBoxModelFilterSet, TenancyFilterSet):
     status = django_filters.MultipleChoiceFilter(choices=StatusChoices, null_value=None)
-    internal_partie = django_filters.MultipleChoiceFilter(
+    internal_party = django_filters.MultipleChoiceFilter(
         choices=InternalEntityChoices, null_value=None
     )
     currency = django_filters.MultipleChoiceFilter(

--- a/netbox_contract/forms.py
+++ b/netbox_contract/forms.py
@@ -51,13 +51,13 @@ plugin_settings = settings.PLUGINS_CONFIG['netbox_contract']
 class ContractForm(NetBoxModelForm):
     comments = CommentField(label=_('Comments'))
 
-    external_partie_object_type = ContentTypeChoiceField(
+    external_party_object_type = ContentTypeChoiceField(
         queryset=ContentType.objects.all(),
         limit_choices_to=SERVICE_PROVIDER_MODELS,
         widget=HTMXSelect(),
-        label=_('External partie object type'),
+        label=_('External party object type'),
     )
-    external_partie_object = forms.ModelChoiceField(queryset=None, label=_('External partie object'))
+    external_party_object = forms.ModelChoiceField(queryset=None, label=_('External party object'))
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False, selector=True, label=_('Tenant'))
     parent = DynamicModelChoiceField(
         queryset=Contract.objects.all(),
@@ -74,24 +74,24 @@ class ContractForm(NetBoxModelForm):
         super().__init__(*args, **kwargs)
 
         # Initialize the external party object gfk
-        if initial and 'external_partie_object_type' in initial:
-            external_partie_object_type = ContentType.objects.get_for_id(initial['external_partie_object_type'])
-            external_partie_class = external_partie_object_type.model_class()
-            self.fields['external_partie_object'].queryset = external_partie_class.objects.all()
+        if initial and 'external_party_object_type' in initial:
+            external_party_object_type = ContentType.objects.get_for_id(initial['external_party_object_type'])
+            external_party_class = external_party_object_type.model_class()
+            self.fields['external_party_object'].queryset = external_party_class.objects.all()
             if (
-                self.instance.external_partie_object_type
-                and self.instance.external_partie_object_type.id == external_partie_object_type.id
+                self.instance.external_party_object_type
+                and self.instance.external_party_object_type.id == external_party_object_type.id
             ):
-                self.fields['external_partie_object'].initial = self.instance.external_partie_object
+                self.fields['external_party_object'].initial = self.instance.external_party_object
             else:
-                self.fields['external_partie_object'].initial = None
-        elif self.instance.external_partie_object_type:
-            external_partie_class = self.instance.external_partie_object_type.model_class()
-            self.fields['external_partie_object'].queryset = external_partie_class.objects.all()
-            self.fields['external_partie_object'].initial = self.instance.external_partie_object
+                self.fields['external_party_object'].initial = None
+        elif self.instance.external_party_object_type:
+            external_party_class = self.instance.external_party_object_type.model_class()
+            self.fields['external_party_object'].queryset = external_party_class.objects.all()
+            self.fields['external_party_object'].initial = self.instance.external_party_object
         else:
-            self.fields['external_partie_object'].queryset = ServiceProvider.objects.all()
-            self.fields['external_partie_object'].initial = None
+            self.fields['external_party_object'].queryset = ServiceProvider.objects.all()
+            self.fields['external_party_object'].initial = None
 
         # Initialise fields settings
         mandatory_fields = plugin_settings.get('mandatory_contract_fields')
@@ -107,10 +107,10 @@ class ContractForm(NetBoxModelForm):
         fields = (
             'name',
             'contract_type',
-            'external_partie_object_type',
-            'external_partie_object',
+            'external_party_object_type',
+            'external_party_object',
             'external_reference',
-            'internal_partie',
+            'internal_party',
             'tenant',
             'status',
             'start_date',
@@ -151,7 +151,7 @@ class ContractFilterForm(ContactModelFilterForm, TenancyFilterForm, NetBoxModelF
         label=_('Contract type'),
     )
     external_reference = forms.CharField(required=False, label=_('External reference'))
-    internal_partie = forms.ChoiceField(choices=InternalEntityChoices, required=False, label=_('Internal partie'))
+    internal_party = forms.ChoiceField(choices=InternalEntityChoices, required=False, label=_('Internal party'))
     status = forms.ChoiceField(choices=StatusChoices, required=False, label=_('Status'))
     currency = forms.ChoiceField(choices=CurrencyChoices, required=False, label=_('Currency'))
     parent = DynamicModelChoiceField(
@@ -164,13 +164,13 @@ class ContractFilterForm(ContactModelFilterForm, TenancyFilterForm, NetBoxModelF
 
 
 class ContractCSVForm(NetBoxModelImportForm):
-    external_partie_object_type = CSVContentTypeField(
+    external_party_object_type = CSVContentTypeField(
         queryset=ContentType.objects.all(),
         limit_choices_to=SERVICE_PROVIDER_MODELS,
         help_text='service provider object type in the form <app>.<model>',
     )
-    external_partie_object_id = forms.CharField(
-        help_text='service provider object name', label=_('External partie name')
+    external_party_object_id = forms.CharField(
+        help_text='service provider object name', label=_('External party name')
     )
     tenant = CSVModelChoiceField(
         queryset=Tenant.objects.all(),
@@ -200,10 +200,10 @@ class ContractCSVForm(NetBoxModelImportForm):
         fields = [
             'name',
             'contract_type',
-            'external_partie_object_type',
-            'external_partie_object_id',
+            'external_party_object_type',
+            'external_party_object_id',
             'external_reference',
-            'internal_partie',
+            'internal_party',
             'tenant',
             'status',
             'start_date',
@@ -220,12 +220,12 @@ class ContractCSVForm(NetBoxModelImportForm):
             'parent',
         ]
 
-    def clean_external_partie_object_id(self):
-        name = self.cleaned_data.get('external_partie_object_id')
-        external_partie_object_type = self.cleaned_data.get('external_partie_object_type')
-        external_partie_object = external_partie_object_type.get_object_for_this_type(name=name)
+    def clean_external_party_object_id(self):
+        name = self.cleaned_data.get('external_party_object_id')
+        external_party_object_type = self.cleaned_data.get('external_party_object_type')
+        external_party_object = external_party_object_type.get_object_for_this_type(name=name)
 
-        return external_partie_object.id
+        return external_party_object.id
 
 
 class ContractBulkEditForm(NetBoxModelBulkEditForm):
@@ -237,7 +237,7 @@ class ContractBulkEditForm(NetBoxModelBulkEditForm):
         label=_('Contract Type')
     )
     external_reference = forms.CharField(max_length=100, required=False, label=_('External reference'))
-    internal_partie = forms.ChoiceField(choices=InternalEntityChoices, required=False, label=_('Internal partie'))
+    internal_party = forms.ChoiceField(choices=InternalEntityChoices, required=False, label=_('Internal party'))
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False, selector=True, label=_('Tenant'))
     comments = CommentField(required=False, label=_('Comments'))
     parent = DynamicModelChoiceField(

--- a/netbox_contract/locale/en/LC_MESSAGES/django.po
+++ b/netbox_contract/locale/en/LC_MESSAGES/django.po
@@ -23,11 +23,11 @@ msgid "Comments"
 msgstr ""
 
 #: forms.py:69
-msgid "External partie object type"
+msgid "External party object type"
 msgstr ""
 
 #: forms.py:71
-msgid "External partie object"
+msgid "External party object"
 msgstr ""
 
 #: forms.py:73 forms.py:173 forms.py:199 forms.py:267
@@ -53,7 +53,7 @@ msgid "External reference"
 msgstr ""
 
 #: forms.py:176 forms.py:261 templates/netbox_contract/contract.html:38
-msgid "Internal partie"
+msgid "Internal party"
 msgstr ""
 
 #: forms.py:177 forms.py:204 forms.py:716
@@ -71,7 +71,7 @@ msgid "Currency"
 msgstr ""
 
 #: forms.py:192
-msgid "External partie name"
+msgid "External party name"
 msgstr ""
 
 #: forms.py:252 forms.py:523 forms.py:540 forms.py:711 forms.py:735
@@ -223,11 +223,11 @@ msgid "contract assignments"
 msgstr ""
 
 #: models.py:178
-msgid "external partie object type"
+msgid "external party object type"
 msgstr ""
 
 #: models.py:183
-msgid "external partie object ID"
+msgid "external party object ID"
 msgstr ""
 
 #: models.py:193
@@ -235,7 +235,7 @@ msgid "external reference"
 msgstr ""
 
 #: models.py:198
-msgid "internal partie"
+msgid "internal party"
 msgstr ""
 
 #: models.py:206
@@ -389,11 +389,11 @@ msgid "Accounting dimension"
 msgstr ""
 
 #: templates/netbox_contract/contract.html:20
-msgid "External partie type"
+msgid "External party type"
 msgstr ""
 
 #: templates/netbox_contract/contract.html:24
-msgid "External partie"
+msgid "External party"
 msgstr ""
 
 #: templates/netbox_contract/contract.html:49

--- a/netbox_contract/locale/fr/LC_MESSAGES/django.po
+++ b/netbox_contract/locale/fr/LC_MESSAGES/django.po
@@ -27,11 +27,11 @@ msgid "Comments"
 msgstr "Commentaires"
 
 #: forms.py:69
-msgid "External partie object type"
+msgid "External party object type"
 msgstr "Type de prestataire "
 
 #: forms.py:71
-msgid "External partie object"
+msgid "External party object"
 msgstr "Prestataire"
 
 #: forms.py:73 forms.py:173 forms.py:199 forms.py:267
@@ -57,7 +57,7 @@ msgid "External reference"
 msgstr "Reference externe"
 
 #: forms.py:176 forms.py:261 templates/netbox_contract/contract.html:38
-msgid "Internal partie"
+msgid "Internal party"
 msgstr "Entité interne"
 
 #: forms.py:177 forms.py:204 forms.py:716
@@ -75,7 +75,7 @@ msgid "Currency"
 msgstr "Devise"
 
 #: forms.py:192
-msgid "External partie name"
+msgid "External party name"
 msgstr "Nom du prestataire"
 
 #: forms.py:252 forms.py:523 forms.py:540 forms.py:711 forms.py:735
@@ -227,11 +227,11 @@ msgid "contract assignments"
 msgstr "objets du contrat"
 
 #: models.py:178
-msgid "external partie object type"
+msgid "external party object type"
 msgstr "type de prestataire "
 
 #: models.py:183
-msgid "external partie object ID"
+msgid "external party object ID"
 msgstr "identifiant du prestataire "
 
 #: models.py:193
@@ -239,7 +239,7 @@ msgid "external reference"
 msgstr "réference externe"
 
 #: models.py:198
-msgid "internal partie"
+msgid "internal party"
 msgstr "entité interne"
 
 #: models.py:206
@@ -393,11 +393,11 @@ msgid "Accounting dimension"
 msgstr "Dimension comptable"
 
 #: templates/netbox_contract/contract.html:20
-msgid "External partie type"
+msgid "External party type"
 msgstr "Type de prestataire "
 
 #: templates/netbox_contract/contract.html:24
-msgid "External partie"
+msgid "External party"
 msgstr "Prestataire"
 
 #: templates/netbox_contract/contract.html:49

--- a/netbox_contract/migrations/0001_initial.py
+++ b/netbox_contract/migrations/0001_initial.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ('name', models.CharField(max_length=100)),
-                ('internal_partie', models.CharField(default='Active', max_length=50)),
+                ('internal_party', models.CharField(default='Active', max_length=50)),
                 ('status', models.CharField(default='Active', max_length=50)),
                 ('start_date', models.DateField()),
                 ('initial_term', models.IntegerField(default=12)),
@@ -137,7 +137,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='contract',
-            name='external_partie',
+            name='external_party',
             field=models.ForeignKey(
                 on_delete=django.db.models.deletion.CASCADE,
                 related_name='contract',

--- a/netbox_contract/migrations/0002_alter_contract_circuit_and_more.py
+++ b/netbox_contract/migrations/0002_alter_contract_circuit_and_more.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterField(
             model_name='contract',
-            name='external_partie',
+            name='external_party',
             field=models.ForeignKey(
                 on_delete=django.db.models.deletion.CASCADE,
                 related_name='contracts',

--- a/netbox_contract/migrations/0018_contract_external_party_object_id_and_more.py
+++ b/netbox_contract/migrations/0018_contract_external_party_object_id_and_more.py
@@ -13,12 +13,12 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='contract',
-            name='external_partie_object_id',
+            name='external_party_object_id',
             field=models.PositiveBigIntegerField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name='contract',
-            name='external_partie_object_type',
+            name='external_party_object_type',
             field=models.ForeignKey(
                 blank=True,
                 null=True,
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
         migrations.AddIndex(
             model_name='contract',
             index=models.Index(
-                fields=['external_partie_object_type', 'external_partie_object_id'],
+                fields=['external_party_object_type', 'external_party_object_id'],
                 name='netbox_cont_externa_6343fb_idx',
             ),
         ),

--- a/netbox_contract/migrations/0019_auto_20230924_1813.py
+++ b/netbox_contract/migrations/0019_auto_20230924_1813.py
@@ -3,7 +3,7 @@
 from django.db import migrations
 
 
-def migrate_external_partie(apps, schema_editor):
+def migrate_external_party(apps, schema_editor):
     """
     Migrate contract Service providers to the new model
     """
@@ -16,28 +16,28 @@ def migrate_external_partie(apps, schema_editor):
     )
 
     for contract in Contract.objects.all():
-        contract.external_partie_object_type = ServiceProviderType
-        contract.external_partie_object_id = contract.external_partie.id
+        contract.external_party_object_type = ServiceProviderType
+        contract.external_party_object_id = contract.external_party.id
         contract.save()
 
 
-def reverse_external_partie(apps, schema_editor):
+def reverse_external_party(apps, schema_editor):
     """
     Migrate contract Service providers to the new model
     """
     Contract = apps.get_model('netbox_contract', 'Contract')
 
     for contract in Contract.objects.all():
-        contract.external_partie_object_type = None
-        contract.external_partie_object_id = None
+        contract.external_party_object_type = None
+        contract.external_party_object_id = None
         contract.save()
 
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('netbox_contract', '0018_contract_external_partie_object_id_and_more'),
+        ('netbox_contract', '0018_contract_external_party_object_id_and_more'),
     ]
 
     operations = [
-    #    migrations.RunPython(migrate_external_partie, reverse_external_partie),
+    #    migrations.RunPython(migrate_external_party, reverse_external_party),
     ]

--- a/netbox_contract/migrations/0020_alter_contract_external_party.py
+++ b/netbox_contract/migrations/0020_alter_contract_external_party.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterField(
             model_name='contract',
-            name='external_partie',
+            name='external_party',
             field=models.ForeignKey(
                 blank=True,
                 on_delete=django.db.models.deletion.CASCADE,

--- a/netbox_contract/migrations/0021_alter_contract_external_party.py
+++ b/netbox_contract/migrations/0021_alter_contract_external_party.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('netbox_contract', '0020_alter_contract_external_partie'),
+        ('netbox_contract', '0020_alter_contract_external_party'),
     ]
 
     operations = [
         migrations.AlterField(
             model_name='contract',
-            name='external_partie',
+            name='external_party',
             field=models.ForeignKey(
                 blank=True,
                 null=True,

--- a/netbox_contract/migrations/0022_alter_contract_internal_party_alter_contract_parent.py
+++ b/netbox_contract/migrations/0022_alter_contract_internal_party_alter_contract_parent.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('netbox_contract', '0021_alter_contract_external_partie'),
+        ('netbox_contract', '0021_alter_contract_external_party'),
     ]
 
     operations = [
         migrations.AlterField(
             model_name='contract',
-            name='internal_partie',
+            name='internal_party',
             field=models.CharField(max_length=50),
         ),
         migrations.AlterField(

--- a/netbox_contract/migrations/0023_rename_contractassignement_contractassignment_and_more.py
+++ b/netbox_contract/migrations/0023_rename_contractassignement_contractassignment_and_more.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
         ('contenttypes', '0002_remove_content_type_name'),
         (
             'netbox_contract',
-            '0022_alter_contract_internal_partie_alter_contract_parent',
+            '0022_alter_contract_internal_party_alter_contract_parent',
         ),
     ]
 

--- a/netbox_contract/migrations/0024_remove_contract_external_party.py
+++ b/netbox_contract/migrations/0024_remove_contract_external_party.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RemoveField(
             model_name='contract',
-            name='external_partie',
+            name='external_party',
         ),
     ]

--- a/netbox_contract/migrations/0025_remove_contract_circuit_and_more.py
+++ b/netbox_contract/migrations/0025_remove_contract_circuit_and_more.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('netbox_contract', '0024_remove_contract_external_partie'),
+        ('netbox_contract', '0024_remove_contract_external_party'),
     ]
 
     operations = [

--- a/netbox_contract/models.py
+++ b/netbox_contract/models.py
@@ -40,7 +40,7 @@ class AccountingDimensionStatusChoices(ChoiceSet):
 
 
 class InternalEntityChoices(ChoiceSet):
-    key = 'Contract.internal_partie'
+    key = 'Contract.internal_party'
 
     ENTITY = 'Default entity'
 
@@ -182,22 +182,22 @@ class Contract(ContactsMixin, NetBoxModel):
         null=True,
         verbose_name=_('contract type'),
     )
-    external_partie_object_type = models.ForeignKey(
+    external_party_object_type = models.ForeignKey(
         to=ContentType,
         on_delete=models.CASCADE,
         blank=True,
         null=True,
-        verbose_name=_('external partie object type'),
+        verbose_name=_('external party object type'),
     )
-    external_partie_object_id = models.PositiveBigIntegerField(
-        blank=True, null=True, verbose_name=_('external partie object ID')
+    external_party_object_id = models.PositiveBigIntegerField(
+        blank=True, null=True, verbose_name=_('external party object ID')
     )
-    external_partie_object = GenericForeignKey(
-        ct_field='external_partie_object_type', fk_field='external_partie_object_id'
+    external_party_object = GenericForeignKey(
+        ct_field='external_party_object_type', fk_field='external_party_object_id'
     )
-    external_partie_object.editable = True
+    external_party_object.editable = True
     external_reference = models.CharField(max_length=100, blank=True, null=True, verbose_name=_('external reference'))
-    internal_partie = models.CharField(max_length=50, choices=InternalEntityChoices, verbose_name=_('internal partie'))
+    internal_party = models.CharField(max_length=50, choices=InternalEntityChoices, verbose_name=_('internal party'))
     tenant = models.ForeignKey(
         to='tenancy.Tenant',
         on_delete=models.PROTECT,
@@ -285,7 +285,7 @@ class Contract(ContactsMixin, NetBoxModel):
     class Meta:
         ordering = ('name',)
         indexes = [
-            models.Index(fields=['external_partie_object_type', 'external_partie_object_id']),
+            models.Index(fields=['external_party_object_type', 'external_party_object_id']),
         ]
         verbose_name = _('contract')
         verbose_name_plural = _('contracts')

--- a/netbox_contract/tables.py
+++ b/netbox_contract/tables.py
@@ -30,7 +30,7 @@ class ContractAssignmentListTable(NetBoxTable):
     content_object = tables.Column(linkify=True, orderable=False)
     contract = tables.Column(linkify=True)
     actions = columns.ActionsColumn(actions=('edit', 'delete'))
-    contract__external_partie_object = tables.Column(linkify=True)
+    contract__external_party_object = tables.Column(linkify=True)
     tags = columns.TagColumn(url_name='plugins:netbox_contract:contractassignment_list')
     contract__contract_type = columns.ColoredLabelColumn(verbose_name='Contract type')
 
@@ -42,8 +42,8 @@ class ContractAssignmentListTable(NetBoxTable):
             'content_object',
             'contract',
             'contract__contract_type',
-            'contract__external_partie_object_type',
-            'contract__external_partie_object',
+            'contract__external_party_object_type',
+            'contract__external_party_object',
             'actions',
         )
         default_columns = (
@@ -52,15 +52,15 @@ class ContractAssignmentListTable(NetBoxTable):
             'content_object',
             'contract',
             'contract__contract_type',
-            'contract__external_partie_object_type',
-            'contract__external_partie_object',
+            'contract__external_party_object_type',
+            'contract__external_party_object',
         )
 
 
 class ContractAssignmentObjectTable(NetBoxTable):
     contract = tables.Column(linkify=True)
     actions = columns.ActionsColumn(actions=('edit', 'delete'))
-    contract__external_partie_object = tables.Column(
+    contract__external_party_object = tables.Column(
         verbose_name='Partner', linkify=True
     )
     contract__status = columns.ChoiceFieldColumn(
@@ -74,7 +74,7 @@ class ContractAssignmentObjectTable(NetBoxTable):
         fields = (
             'pk',
             'contract',
-            'contract__external_partie_object',
+            'contract__external_party_object',
             'contract__status',
             'contract__contract_type',
             'contract__start_date',
@@ -86,8 +86,8 @@ class ContractAssignmentObjectTable(NetBoxTable):
         default_columns = (
             'pk',
             'contract',
-            'contract__external_partie_object_type',
-            'contract__external_partie_object',
+            'contract__external_party_object_type',
+            'contract__external_party_object',
             'contract__status',
             'contract__contract_type',
             'contract__start_date',
@@ -124,7 +124,7 @@ class ContractAssignmentContractTable(NetBoxTable):
 
 class ContractListTable(ContactsColumnMixin, NetBoxTable):
     name = tables.Column(linkify=True)
-    external_partie_object = tables.Column(verbose_name='External partie', linkify=True)
+    external_party_object = tables.Column(verbose_name='External party', linkify=True)
     parent = tables.Column(linkify=True)
     yrc = tables.Column(verbose_name='Yerly recuring costs')
     status = columns.ChoiceFieldColumn(
@@ -140,10 +140,10 @@ class ContractListTable(ContactsColumnMixin, NetBoxTable):
             'id',
             'name',
             'contract_type',
-            'external_partie_object_type',
-            'external_partie_object',
+            'external_party_object_type',
+            'external_party_object',
             'external_reference',
-            'internal_partie',
+            'internal_party',
             'tenant',
             'status',
             'start_date',
@@ -165,7 +165,7 @@ class ContractListTable(ContactsColumnMixin, NetBoxTable):
 
 class ContractListBottomTable(NetBoxTable):
     name = tables.Column(linkify=True)
-    external_partie_object = tables.Column(linkify=True)
+    external_party_object = tables.Column(linkify=True)
     status = columns.ChoiceFieldColumn(
         verbose_name=('Status'),
     )
@@ -176,10 +176,10 @@ class ContractListBottomTable(NetBoxTable):
             'pk',
             'id',
             'name',
-            'external_partie_object_type',
-            'external_partie_object',
+            'external_party_object_type',
+            'external_party_object',
             'external_reference',
-            'internal_partie',
+            'internal_party',
             'status',
             'mrc',
             'comments',
@@ -187,8 +187,8 @@ class ContractListBottomTable(NetBoxTable):
         )
         default_columns = (
             'name',
-            'external_partie_object_type',
-            'external_partie_object',
+            'external_party_object_type',
+            'external_party_object',
             'status',
         )
 

--- a/netbox_contract/templates/netbox_contract/contract.html
+++ b/netbox_contract/templates/netbox_contract/contract.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item"><a href="{% url 'plugins:netbox_contract:contract_list' %}?external_partie={{ object.external_partie.pk }}">{{ object.external_partie }}</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'plugins:netbox_contract:contract_list' %}?external_party={{ object.external_party.pk }}">{{ object.external_party }}</a></li>
 {% endblock %}
 {% block content %}
   <div class="row mb-3">
@@ -23,13 +23,13 @@
               </td>
             </tr>
             <tr>
-              <th scope="row">{% trans "External partie type" %}</th>
-              <td>{{ object.external_partie_object_type }}</td>
+              <th scope="row">{% trans "External party type" %}</th>
+              <td>{{ object.external_party_object_type }}</td>
             </tr>
             <tr>
-              <th scope="row">{% trans "External partie" %}</th>
+              <th scope="row">{% trans "External party" %}</th>
               <td>
-                <a href="{{ object.external_partie_object.get_absolute_url }}">{{ object.external_partie_object.name }}</a>
+                <a href="{{ object.external_party_object.get_absolute_url }}">{{ object.external_party_object.name }}</a>
               </td>
             </tr>
             <tr>
@@ -41,8 +41,8 @@
               <td>{{ object.external_reference }}</td>
             </tr>
             <tr>
-              <th scope="row">{% trans "Internal partie" %}</th>
-              <td>{{ object.internal_partie }}</td>
+              <th scope="row">{% trans "Internal party" %}</th>
+              <td>{{ object.internal_party }}</td>
             </tr>
             {% if not 'tenant' in hidden_fields %}
             <tr>

--- a/netbox_contract/tests/test_views.py
+++ b/netbox_contract/tests/test_views.py
@@ -43,9 +43,9 @@ class ContractTestCase(ModelViewTestCase, ViewTestCases.PrimaryObjectViewTestCas
         contract1 = Contract.objects.create(
             name='Contract1',
             contract_type=ContractType.objects.get(name='Contract Type A'),
-            external_partie_object_type=ContentType.objects.get_for_model(Provider),
-            external_partie_object_id=Provider.objects.get(slug='provider-a').id,
-            internal_partie='default',
+            external_party_object_type=ContentType.objects.get_for_model(Provider),
+            external_party_object_id=Provider.objects.get(slug='provider-a').id,
+            internal_party='default',
             status=StatusChoices.STATUS_ACTIVE,
             start_date=date(2025, 1, 1),
             end_date=date(2025, 12, 31),
@@ -56,9 +56,9 @@ class ContractTestCase(ModelViewTestCase, ViewTestCases.PrimaryObjectViewTestCas
 
         contract2 = Contract.objects.create(
             name='Contract2',
-            external_partie_object_type=ContentType.objects.get_for_model(Provider),
-            external_partie_object_id=Provider.objects.get(slug='provider-a').id,
-            internal_partie='default',
+            external_party_object_type=ContentType.objects.get_for_model(Provider),
+            external_party_object_id=Provider.objects.get(slug='provider-a').id,
+            internal_party='default',
             status=StatusChoices.STATUS_ACTIVE,
             start_date=date(2025, 1, 1),
             end_date=date(2025, 12, 31),
@@ -69,9 +69,9 @@ class ContractTestCase(ModelViewTestCase, ViewTestCases.PrimaryObjectViewTestCas
 
         contract3 = Contract.objects.create(
             name='Contract3',
-            external_partie_object_type=ContentType.objects.get_for_model(Provider),
-            external_partie_object_id=Provider.objects.get(slug='provider-a').id,
-            internal_partie='default',
+            external_party_object_type=ContentType.objects.get_for_model(Provider),
+            external_party_object_id=Provider.objects.get(slug='provider-a').id,
+            internal_party='default',
             status=StatusChoices.STATUS_ACTIVE,
             start_date=date(2025, 1, 1),
             end_date=date(2025, 12, 31),
@@ -83,10 +83,10 @@ class ContractTestCase(ModelViewTestCase, ViewTestCases.PrimaryObjectViewTestCas
         cls.form_data = {
             'name': 'Contract X',
             'contract_type': ContractType.objects.get(name='Contract Type A').pk,
-            'external_partie_object_type': ContentType.objects.get_for_model(Provider).pk,
-            'external_partie_object': Provider.objects.get(slug='provider-a').id,
+            'external_party_object_type': ContentType.objects.get_for_model(Provider).pk,
+            'external_party_object': Provider.objects.get(slug='provider-a').id,
             'external_reference': 'External Reference 1',
-            'internal_partie': 'default',
+            'internal_party': 'default',
             'tenant': Tenant.objects.get(name='Tenant 1').id,
             'status': StatusChoices.STATUS_ACTIVE,
             'start_date': date(2025, 1, 1),
@@ -101,7 +101,7 @@ class ContractTestCase(ModelViewTestCase, ViewTestCases.PrimaryObjectViewTestCas
         }
 
         cls.csv_data = (
-            'name,contract_type,external_partie_object_type,external_partie_object_id,internal_partie,'
+            'name,contract_type,external_party_object_type,external_party_object_id,internal_party,'
             'tenant,status,start_date,end_date,currency,mrc,nrc,invoice_frequency',
             'Contract 4,Contract Type A,netbox_contract.serviceprovider,Service Provider A,entity1,'
             'Tenant 1,active,2025-01-01,2025-12-31,usd,100,1000,1',
@@ -135,9 +135,9 @@ class InvoiceTestCase(ModelViewTestCase, ViewTestCases.PrimaryObjectViewTestCase
         # Create test Contract
         contract1 = Contract.objects.create(
             name='Contract1',
-            external_partie_object_type=ContentType.objects.get_for_model(Provider),
-            external_partie_object_id=Provider.objects.get(slug='provider-a').id,
-            internal_partie='default',
+            external_party_object_type=ContentType.objects.get_for_model(Provider),
+            external_party_object_id=Provider.objects.get(slug='provider-a').id,
+            internal_party='default',
             status=StatusChoices.STATUS_ACTIVE,
             start_date=date(2025, 1, 1),
             end_date=date(2025, 12, 31),
@@ -401,9 +401,9 @@ class ContractAssignmentTestCase(ModelViewTestCase, ViewTestCases.PrimaryObjectV
         # Create a test Contract
         contract1 = Contract.objects.create(
             name='Contract1',
-            external_partie_object_type=ContentType.objects.get_for_model(ServiceProvider),
-            external_partie_object_id=ServiceProvider.objects.get(slug='service-provider-1').id,
-            internal_partie='default',
+            external_party_object_type=ContentType.objects.get_for_model(ServiceProvider),
+            external_party_object_id=ServiceProvider.objects.get(slug='service-provider-1').id,
+            internal_party='default',
             status=StatusChoices.STATUS_ACTIVE,
             start_date=date(2025, 1, 1),
             end_date=date(2025, 12, 31),
@@ -429,9 +429,9 @@ class ContractAssignmentTestCase(ModelViewTestCase, ViewTestCases.PrimaryObjectV
 
         contract2 = Contract.objects.create(
             name='Contract2',
-            external_partie_object_type=ContentType.objects.get_for_model(Provider),
-            external_partie_object_id=Provider.objects.get(slug='provider-a').id,
-            internal_partie='default',
+            external_party_object_type=ContentType.objects.get_for_model(Provider),
+            external_party_object_id=Provider.objects.get(slug='provider-a').id,
+            internal_party='default',
             status=StatusChoices.STATUS_ACTIVE,
             start_date=date(2025, 1, 1),
             end_date=date(2025, 12, 31),
@@ -478,9 +478,9 @@ class ContractAssignmentTestCase(ModelViewTestCase, ViewTestCases.PrimaryObjectV
         # contract for bulk edition
         contract3 = Contract.objects.create(
             name='Contract3',
-            external_partie_object_type=ContentType.objects.get_for_model(ServiceProvider),
-            external_partie_object_id=ServiceProvider.objects.get(slug='service-provider-1').id,
-            internal_partie='default',
+            external_party_object_type=ContentType.objects.get_for_model(ServiceProvider),
+            external_party_object_id=ServiceProvider.objects.get(slug='service-provider-1').id,
+            internal_party='default',
             status=StatusChoices.STATUS_ACTIVE,
             start_date=date(2025, 1, 1),
             end_date=date(2025, 12, 31),

--- a/netbox_contract/views.py
+++ b/netbox_contract/views.py
@@ -256,7 +256,7 @@ class ContractEditView(generic.ObjectEditView):
     def alter_object(self, obj, request, url_args, url_kwargs):
         """
         When this method is called after a Post,
-        it is used here to set the external partie object id for exiting objects,
+        it is used here to set the external party object id for exiting objects,
         In any case, this happens before the form is instanciated.
 
         Args:
@@ -268,15 +268,15 @@ class ContractEditView(generic.ObjectEditView):
 
         if request.method == 'POST':
             data = normalize_querydict(request.POST)
-            obj.external_partie_object_id = data['external_partie_object']
-            external_partie_object_type_id = data['external_partie_object_type']
-            obj.external_partie_object_type = ContentType.objects.get(
-                id=external_partie_object_type_id
+            obj.external_party_object_id = data['external_party_object']
+            external_party_object_type_id = data['external_party_object_type']
+            obj.external_party_object_type = ContentType.objects.get(
+                id=external_party_object_type_id
             )
-            external_partie_object_type = obj.external_partie_object_type
-            obj.external_partie_object = (
-                external_partie_object_type.get_object_for_this_type(
-                    id=obj.external_partie_object_id
+            external_party_object_type = obj.external_party_object_type
+            obj.external_party_object = (
+                external_party_object_type.get_object_for_this_type(
+                    id=obj.external_party_object_id
                 )
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-contract"
-version = "2.4.0"
+version = "2.4.1"
 authors = [
   { name="Marc Lebreuil", email="marc@famillelebreuil.net" },
 ]

--- a/testing/configuration.py
+++ b/testing/configuration.py
@@ -15,7 +15,7 @@ DATABASE = {
 }
 
 FIELD_CHOICES = {
-    'netbox_contract.Contract.internal_partie': (
+    'netbox_contract.Contract.internal_party': (
         ('default', 'Default entity', 'green'),
         ('entity1', 'Entity 1', 'green'),
         ('entity2', 'Entity 2', 'yellow'),

--- a/utils/contract_import.csv
+++ b/utils/contract_import.csv
@@ -1,2 +1,2 @@
-name,external_partie_object_type,external_partie_object_id,internal_partie,tenant,status,start_date,end_date,currency,mrc,nrc,invoice_frequency
+name,external_party_object_type,external_party_object_id,internal_party,tenant,status,start_date,end_date,currency,mrc,nrc,invoice_frequency
 Contract 1,netbox_contract.serviceprovider,Service Provider A,entity1,Tenant 1,active,2025-01-01,2025-12-31,usd,100,1000,1


### PR DESCRIPTION
Fixing spelling of the word "party" across the code base.
No other changes, tested to be working on Netbox v4.3.2, Python 3.12 and based on netbox-contract v2.4.0.
Related to #260, fixes #261 

