### PR TITLE
Expose missing model fields in API serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* [#300](https://github.com/mlebreuil/netbox-contract/issues/300) Expose missing model fields (slug, comments, color, notice_period, documents, status) via API serializers.
 
 ## Version 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* [#300](https://github.com/mlebreuil/netbox-contract/issues/300) Expose missing model fields (slug, comments, color, notice_period, documents, status) via API serializers.
+* [#300](https://github.com/mlebreuil/netbox-contract/issues/300) Expose missing model fields (slug, comments, color, notice_period, documents, status, tags, custom_fields) via API serializers.
 
 ## Version 2
 

--- a/netbox_contract/api/serializers.py
+++ b/netbox_contract/api/serializers.py
@@ -346,10 +346,12 @@ class ContractAssignmentSerializer(NetBoxModelSerializer):
             'object_id',
             'content_object',
             'contract',
+            'tags',
+            'cuustom_fields',
             'created',
             'last_updated',
         )
-        brief_fields = ('id', 'url', 'display', 'content_object', 'contract')
+        brief_fields = ('id', 'url', 'display', 'content_object', 'contract','tags','custom_fields')
 
     @swagger_serializer_method(serializer_or_field=serializers.JSONField)
     def get_content_object(self, instance):

--- a/netbox_contract/api/serializers.py
+++ b/netbox_contract/api/serializers.py
@@ -325,7 +325,7 @@ class ServiceProviderSerializer(NetBoxModelSerializer):
             'created',
             'last_updated',
         )
-        brief_fields = ('id', 'url', 'display', 'name','slug')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug')
 
 
 class ContractAssignmentSerializer(NetBoxModelSerializer):
@@ -347,11 +347,11 @@ class ContractAssignmentSerializer(NetBoxModelSerializer):
             'content_object',
             'contract',
             'tags',
-            'cuustom_fields',
+            'custom_fields',
             'created',
             'last_updated',
         )
-        brief_fields = ('id', 'url', 'display', 'content_object', 'contract','tags','custom_fields')
+        brief_fields = ('id', 'url', 'display', 'content_object', 'contract', 'tags', 'custom_fields')
 
     @swagger_serializer_method(serializer_or_field=serializers.JSONField)
     def get_content_object(self, instance):

--- a/netbox_contract/api/serializers.py
+++ b/netbox_contract/api/serializers.py
@@ -46,12 +46,14 @@ class NestedContractSerializer(WritableNestedSerializer):
             'end_date',
             'initial_term',
             'renewal_term',
+            'notice_period',
             'currency',
             'mrc',
             'yrc',
             'nrc',
             'invoice_frequency',
             'comments',
+            'documents',
         )
 
     @swagger_serializer_method(serializer_or_field=serializers.JSONField)
@@ -98,6 +100,7 @@ class ContractTypeSerializer(NetBoxModelSerializer):
             'display',
             'name',
             'description',
+            'color',
             'tags',
             'custom_fields',
             'created',
@@ -136,12 +139,14 @@ class ContractSerializer(NetBoxModelSerializer):
             'end_date',
             'initial_term',
             'renewal_term',
+            'notice_period',
             'currency',
             'mrc',
             'yrc',
             'nrc',
             'invoice_frequency',
             'comments',
+            'documents',
             'parent',
             'tags',
             'custom_fields',
@@ -205,12 +210,14 @@ class InvoiceSerializer(NetBoxModelSerializer):
             'number',
             'date',
             'template',
+            'status',
             'contracts',
             'period_start',
             'period_end',
             'currency',
             'amount',
             'comments',
+            'documents',
             'tags',
             'custom_fields',
             'created',
@@ -310,13 +317,15 @@ class ServiceProviderSerializer(NetBoxModelSerializer):
             'url',
             'display',
             'name',
+            'slug',
             'portal_url',
+            'comments',
             'tags',
             'custom_fields',
             'created',
             'last_updated',
         )
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name','slug')
 
 
 class ContractAssignmentSerializer(NetBoxModelSerializer):
@@ -411,6 +420,7 @@ class AccountingDimensionSerializer(NetBoxModelSerializer):
             'display',
             'name',
             'value',
+            'status',
             'comments',
             'tags',
             'custom_fields',


### PR DESCRIPTION
  Several model fields were absent from their corresponding API serializer Meta.fields tuple. The most impactful is ServiceProvider.slug, which is required by the model (unique=True, no default) but not declared in the
  serializer, so ServiceProvider creation via the REST API always fails with "slug: This field cannot be blank."

  Adds to Meta.fields (and brief_fields where appropriate):
  - ServiceProviderSerializer: slug, comments
  - ContractTypeSerializer: color
  - ContractSerializer: notice_period, documents
  - NestedContractSerializer: notice_period, documents
  - InvoiceSerializer: status, documents
  - AccountingDimensionSerializer: status

  Closes #300